### PR TITLE
reorder signup fields

### DIFF
--- a/symposion/forms.py
+++ b/symposion/forms.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from django import forms
 
 import account.forms
@@ -12,7 +14,7 @@ class SignupForm(account.forms.SignupForm):
     def __init__(self, *args, **kwargs):
         super(SignupForm, self).__init__(*args, **kwargs)
         del self.fields["username"]
-        self.fields.keyOrder = [
+        key_order = [
             "email",
             "email_confirm",
             "first_name",
@@ -20,6 +22,7 @@ class SignupForm(account.forms.SignupForm):
             "password",
             "password_confirm"
         ]
+        self.fields = reorder_fields(self.fields, key_order)
 
     def clean_email_confirm(self):
         email = self.cleaned_data.get("email")
@@ -29,3 +32,18 @@ class SignupForm(account.forms.SignupForm):
                 raise forms.ValidationError(
                     "Email address must match previously typed email address")
         return email_confirm
+
+
+def reorder_fields(fields, order):
+    """Reorder form fields by order, removing items not in order.
+
+    >>> reorder_fields(
+    ...     OrderedDict([('a', 1), ('b', 2), ('c', 3)]),
+    ...     ['b', 'c', 'a'])
+    OrderedDict([('b', 2), ('c', 3), ('a', 1)])
+    """
+    for key, v in fields.items():
+        if key not in order:
+            del fields[key]
+
+    return OrderedDict(sorted(fields.items(), key=lambda k: order.index(k[0])))


### PR DESCRIPTION
current implementation is not work on Django 1.7+
anymore. This modification activate feature
in Django 1.7+ and drop support for Django 1.6 and before.

Signed-off-by: Hiroshi Miura miurahr@linux.com
