### PR TITLE
use email as account username in default

### DIFF
--- a/symposion/views.py
+++ b/symposion/views.py
@@ -1,14 +1,18 @@
-import hashlib
 import random
 
+from django.core.exceptions import ValidationError
+from django.conf import settings
 from django.shortcuts import render, redirect
 
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
+from django.utils.translation import ugettext_lazy as _
 
 import account.views
 
 import symposion.forms
+
+UNIQUE_EMAIL = getattr(settings, 'ACCOUNT_UNIQUE_EMAIL', True)
 
 
 class SignupView(account.views.SignupView):
@@ -28,17 +32,32 @@ class SignupView(account.views.SignupView):
 
     def generate_username(self, form):
         def random_username():
-            h = hashlib.sha1(form.cleaned_data["email"]).hexdigest()[:25]
+            m = form.cleaned_data["email"]
             # don't ask
             n = random.randint(1, (10 ** (5 - 1)) - 1)
-            return "%s%d" % (h, n)
-        while True:
-            try:
-                username = random_username()
-                User.objects.get(username=username)
-            except User.DoesNotExist:
-                break
-        return username
+            return "%s%d" % (m, n)
+
+        # username = email in most case.
+        username = form.cleaned_data["email"]
+        if not User.objects.filter(username=username):
+            return username
+
+        if UNIQUE_EMAIL:
+            # wish not to happen but will happen
+            # when user change its email and
+            # re-use it when another singup
+            # It is nothing to do special
+            pass
+
+        # fall back to add random number
+        for i in range(1, 2 * (10 ** (5 - 1))):
+            username = random_username()
+            if not User.objects.filter(username=username):
+                return username
+
+        # no way
+        raise ValidationError(_("Cannot process your signup request properly. "
+                                "Please signup again with another email address."))
 
 
 class LoginView(account.views.LoginView):


### PR DESCRIPTION
- Using email directly instead of hashing it.
  it is definitly equivalent things.
  Because 1:1 relation hash with email.
  Because cleaned_email in signup-form of
  account validate email as consist of characters
  that can be used as username.
- avoid try exception block when checking username.

Signed-off-by: Hiroshi Miura miurahr@linux.com
